### PR TITLE
YearnStETHCurveAdapterV1: Added adapter

### DIFF
--- a/src/adapters/yearn/YearnStETHCurveAdapterV1.sol
+++ b/src/adapters/yearn/YearnStETHCurveAdapterV1.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.13;
+
+import {IllegalArgument, IllegalState, Unauthorized} from "../../base/Errors.sol";
+import {Mutex} from "../../base/Mutex.sol";
+
+import {SafeERC20} from "../../libraries/SafeERC20.sol";
+
+import {ITokenAdapter} from "../../interfaces/ITokenAdapter.sol";
+import {IWETH9} from "../../interfaces/external/IWETH9.sol";
+import {IStableSwap2Pool, N_COINS} from "../../interfaces/external/curve/IStableSwap2Pool.sol";
+import {IYearnVaultV2} from "../../interfaces/external/yearn/IYearnVaultV2.sol";
+
+struct InitializationParams {
+    address alchemist;
+    address token;
+    address underlyingToken;
+    address curvePool;
+    address curvePoolToken;
+    uint256 ethPoolIndex;
+    uint256 stEthPoolIndex;
+}
+
+contract YearnStETHCurveAdapterV1 is ITokenAdapter, Mutex {
+    uint256 private constant CURVE_PRECISION = 1e18;
+
+    string public override version = "1.0.0";
+
+    address public immutable alchemist;
+    address public immutable override token;
+    address public immutable override underlyingToken;
+    address public immutable curvePool;
+    address public immutable curvePoolToken;
+    uint256 public immutable ethPoolIndex;
+    uint256 public immutable stEthPoolIndex;
+
+    constructor(InitializationParams memory params) {
+        alchemist        = params.alchemist;
+        token            = params.token;
+        underlyingToken  = params.underlyingToken;
+        curvePool        = params.curvePool;
+        curvePoolToken   = params.curvePoolToken;
+        ethPoolIndex     = params.ethPoolIndex;
+        stEthPoolIndex   = params.stEthPoolIndex;
+
+        // Verify and make sure that the provided ETH matches the yearn pool ETH.
+        if (
+            IStableSwap2Pool(params.curvePool).coins(params.ethPoolIndex) !=
+            0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE
+        ) {
+            revert IllegalArgument("Curve pool ETH token mismatch");
+        }
+    }
+
+    /// @dev Checks that the message sender is the alchemist that the adapter is bound to.
+    modifier onlyAlchemist() {
+        if (msg.sender != alchemist) {
+            revert Unauthorized("Not alchemist");
+        }
+        _;
+    }
+
+    receive() external payable {
+        if (msg.sender != underlyingToken && msg.sender != curvePool) {
+            revert Unauthorized("Payments only permitted from WETH or curve pool");
+        }
+    }
+
+    /// @inheritdoc ITokenAdapter
+    function price() external view returns (uint256) {
+        uint256 poolTokensPerShare = IYearnVaultV2(token).pricePerShare();
+        uint256 assetsPerPoolToken = IStableSwap2Pool(curvePool).get_virtual_price();
+
+        return poolTokensPerShare * assetsPerPoolToken / CURVE_PRECISION;
+    }
+
+    /// @inheritdoc ITokenAdapter
+    function wrap(
+        uint256 amount,
+        address recipient
+    ) external lock onlyAlchemist returns (uint256) {
+        // Transfer the tokens from the message sender.
+        SafeERC20.safeTransferFrom(underlyingToken, msg.sender, address(this), amount);
+
+        // Unwrap the WETH into ETH.
+        IWETH9(underlyingToken).withdraw(amount);
+
+        // Single side deposit the ETH into the curve pool.
+        uint256[N_COINS] memory amounts;
+        amounts[ethPoolIndex] = amount;
+
+        uint256 mintedPoolTokens = IStableSwap2Pool(curvePool).add_liquidity{value: amount}(
+            amounts, // Still have to specify the amounts even though we send ETH.
+            0        // Slippage is handled upstream.
+        );
+
+        // Approve the vault to transfer the tokens.
+        SafeERC20.safeApprove(curvePoolToken, token, mintedPoolTokens);
+
+        // Deposit the curve pool tokens into yearn.
+        return IYearnVaultV2(token).deposit(mintedPoolTokens, recipient);
+    }
+
+    // @inheritdoc ITokenAdapter
+    function unwrap(
+        uint256 amount,
+        address recipient
+    ) external lock onlyAlchemist returns (uint256) {
+        // Transfer the tokens from the message sender.
+        SafeERC20.safeTransferFrom(token, msg.sender, address(this), amount);
+
+        // Withdraw the pool tokens from yearn.
+        uint256 withdrawnPoolTokens = IYearnVaultV2(token).withdraw(amount, address(this), 0);
+
+        // Single sided withdraw ETH from the pool.
+        uint256 received = IStableSwap2Pool(curvePool).remove_liquidity_one_coin(
+            withdrawnPoolTokens,
+            int128(uint128(ethPoolIndex)),
+            0
+        );
+
+        // Wrap the ETH that we received from the exchange.
+        IWETH9(underlyingToken).deposit{value: received}();
+
+        // Transfer the tokens to the recipient.
+        SafeERC20.safeTransfer(underlyingToken, recipient, received);
+
+        return received;
+    }
+}

--- a/src/interfaces/external/curve/IStableSwap2Pool.sol
+++ b/src/interfaces/external/curve/IStableSwap2Pool.sol
@@ -15,7 +15,10 @@ interface IStableSwap2Pool {
         bool deposit
     ) external view returns (uint256 amount);
 
-    function add_liquidity(uint256[N_COINS] calldata amounts, uint256 minimumMintAmount) external;
+    function add_liquidity(
+        uint256[N_COINS] calldata amounts,
+        uint256 minimumMintAmount
+    ) external payable returns (uint256);
 
     function get_dy(int128 i, int128 j, uint256 dx) external view returns (uint256 dy);
 
@@ -41,5 +44,5 @@ interface IStableSwap2Pool {
         uint256 tokenAmount,
         int128 i,
         uint256 minimumAmount
-    ) external;
+    ) external returns (uint256);
 }

--- a/src/interfaces/external/yearn/IYearnVaultV2.sol
+++ b/src/interfaces/external/yearn/IYearnVaultV2.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.5.0;
+
+import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
+import {IERC20Metadata} from "../../IERC20Metadata.sol";
+
+/// @title  IYearnVaultV2
+/// @author Yearn Finance
+interface IYearnVaultV2 is IERC20, IERC20Metadata {
+  struct StrategyParams {
+    uint256 performanceFee;
+    uint256 activation;
+    uint256 debtRatio;
+    uint256 minDebtPerHarvest;
+    uint256 maxDebtPerHarvest;
+    uint256 lastReport;
+    uint256 totalDebt;
+    uint256 totalGain;
+    uint256 totalLoss;
+    bool enforceChangeLimit;
+    uint256 profitLimitRatio;
+    uint256 lossLimitRatio;
+    address customCheck;
+  }
+
+  function apiVersion() external pure returns (string memory);
+
+  function permit(
+    address owner,
+    address spender,
+    uint256 amount,
+    uint256 expiry,
+    bytes calldata signature
+  ) external returns (bool);
+
+  // NOTE: Vyper produces multiple signatures for a given function with "default" args
+  function deposit() external returns (uint256);
+
+  function deposit(uint256 amount) external returns (uint256);
+
+  function deposit(uint256 amount, address recipient) external returns (uint256);
+
+  // NOTE: Vyper produces multiple signatures for a given function with "default" args
+  function withdraw() external returns (uint256);
+
+  function withdraw(uint256 maxShares) external returns (uint256);
+
+  function withdraw(uint256 maxShares, address recipient) external returns (uint256);
+
+  function withdraw(
+    uint256 maxShares,
+    address recipient,
+    uint256 maxLoss
+  ) external returns (uint256);
+
+  function token() external view returns (address);
+
+  function strategies(address _strategy) external view returns (StrategyParams memory);
+
+  function pricePerShare() external view returns (uint256);
+
+  function totalAssets() external view returns (uint256);
+
+  function depositLimit() external view returns (uint256);
+
+  function maxAvailableShares() external view returns (uint256);
+
+  /// @notice View how much the Vault would increase this Strategy's borrow limit, based on its present performance
+  ///         (since its last report). Can be used to determine expectedReturn in your Strategy.
+  function creditAvailable() external view returns (uint256);
+
+  /// @notice View how much the Vault would like to pull back from the Strategy, based on its present performance
+  ///         (since its last report). Can be used to determine expectedReturn in your Strategy.
+  function debtOutstanding() external view returns (uint256);
+
+  /// @notice View how much the Vault expect this Strategy to return at the current block, based on its present
+  ///         performance (since its last report). Can be used to determine expectedReturn in your Strategy.
+  function expectedReturn() external view returns (uint256);
+
+  /// @notice This is the main contact point where the Strategy interacts with the Vault. It is critical that this call
+  ///         is handled as intended by the Strategy. Therefore, this function will be called by BaseStrategy to make
+  ///         sure the integration is correct.
+  function report(
+    uint256 _gain,
+    uint256 _loss,
+    uint256 _debtPayment
+  ) external returns (uint256);
+
+  /// @notice This function should only be used in the scenario where the Strategy is being retired but no migration of
+  ///         the positions are possible, or in the extreme scenario that the Strategy needs to be put into
+  ///         "Emergency Exit" mode in order for it to exit as quickly as possible. The latter scenario could be for any
+  ///         reason that is considered "critical" that the Strategy exits its position as fast as possible, such as a
+  ///         sudden change in market conditions leading to losses, or an imminent failure in an external dependency.
+  function revokeStrategy() external;
+
+  /// @notice View the governance address of the Vault to assert privileged functions can only be called by governance.
+  ///         The Strategy serves the Vault, so it is subject to governance defined by the Vault.
+  function governance() external view returns (address);
+
+  /// @notice View the management address of the Vault to assert privileged functions can only be called by management.
+  ///         The Strategy serves the Vault, so it is subject to management defined by the Vault.
+  function management() external view returns (address);
+
+  /// @notice View the guardian address of the Vault to assert privileged functions can only be called by guardian. The
+  ///         Strategy serves the Vault, so it is subject to guardian defined by the Vault.
+  function guardian() external view returns (address);
+}

--- a/src/libraries/SafeERC20.sol
+++ b/src/libraries/SafeERC20.sol
@@ -19,7 +19,7 @@ library SafeERC20 {
 
             mstore(pointer, 0x313ce56700000000000000000000000000000000000000000000000000000000)
 
-            status := staticcall(gas(), token, pointer, 4, 0, 0)
+            status := staticcall(gas(), token, pointer, 4, 0, 32)
         }
 
         (uint256 decimals, bool success) = expectUInt256Response(status);
@@ -44,7 +44,7 @@ library SafeERC20 {
             mstore(add(pointer,  4), and(spender, 0xffffffffffffffffffffffffffffffffffffffff))
             mstore(add(pointer, 36), value)
 
-            status := call(gas(), token, 0, pointer, 68, 0, 0)
+            status := call(gas(), token, 0, pointer, 68, 0, 32)
         }
 
         if (!checkBooleanResponse(status)) {
@@ -66,7 +66,7 @@ library SafeERC20 {
             mstore(add(pointer,  4), and(receiver, 0xffffffffffffffffffffffffffffffffffffffff))
             mstore(add(pointer, 36), amount)
 
-            status := call(gas(), token, 0, pointer, 68, 0, 0)
+            status := call(gas(), token, 0, pointer, 68, 0, 32)
         }
 
         if (!checkBooleanResponse(status)) {
@@ -95,7 +95,7 @@ library SafeERC20 {
             mstore(add(pointer, 36), and(receiver, 0xffffffffffffffffffffffffffffffffffffffff))
             mstore(add(pointer, 68), amount)
 
-            status := call(gas(), token, 0, pointer, 100, 0, 0)
+            status := call(gas(), token, 0, pointer, 100, 0, 32)
         }
 
         if (!checkBooleanResponse(status)) {
@@ -108,10 +108,8 @@ library SafeERC20 {
     /// When a call is unsuccessful the return data is expected to be error data. The data is
     /// rethrown to bubble up the error to the caller.
     ///
-    /// When a call is successful it is expected that the return data is empty or exactly 32
-    /// bytes in length. Any other return size is treated as an error. When the return data is
-    /// non-empty, it is expected that the return data is non-zero to indicate that the call was
-    /// successful.
+    /// When a call is successful it is expected that the return data is empty or greater than 31
+    /// bytes in length and the value returned is exactly equal to 1.
     ///
     /// @param status A flag indicating if the call has reverted or not.
     ///
@@ -124,18 +122,10 @@ library SafeERC20 {
                 revert(0, returndatasize())
             }
 
-            switch returndatasize()
-            case 32 {
-                returndatacopy(0, 0, returndatasize())
-
-                success := iszero(iszero(mload(0)))
-            }
-            case 0 {
-                success := 1
-            }
-            default {
-                success := 0
-            }
+            success := or(
+                and(eq(mload(0), 1), gt(returndatasize(), 31)),
+                iszero(returndatasize())
+            )
         }
     }
 
@@ -162,8 +152,6 @@ library SafeERC20 {
 
             switch returndatasize()
             case 32 {
-                returndatacopy(0, 0, returndatasize())
-
                 value   := mload(0)
                 success := 1
             }

--- a/src/libraries/SafeERC20.sol
+++ b/src/libraries/SafeERC20.sol
@@ -2,6 +2,7 @@
 pragma solidity >=0.8.4;
 
 import {IllegalState} from "../base/Errors.sol";
+import "forge-std/console.sol";
 
 /// @title  SafeERC20
 /// @author Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/utils/SafeTransferLib.sol)
@@ -150,8 +151,8 @@ library SafeERC20 {
                 revert(0, returndatasize())
             }
 
-            switch returndatasize()
-            case 32 {
+            switch gt(returndatasize(), 31)
+            case 1 {
                 value   := mload(0)
                 success := 1
             }

--- a/src/test/RETHAdapterV1.t.sol
+++ b/src/test/RETHAdapterV1.t.sol
@@ -32,8 +32,6 @@ contract RocketStakedEthereumAdapterV1Test is DSTestPlus, stdCheats {
             token:           address(rETH),
             underlyingToken: address(weth)
         }));
-
-        console.log(adapter.token());
     }
 
     function testPrice() external {

--- a/src/test/SafeERC20.t.sol
+++ b/src/test/SafeERC20.t.sol
@@ -23,14 +23,6 @@ contract SafeERC20Test is DSTestPlus {
         assertEq(SafeERC20.expectDecimals(address(token)), decimals);
     }
 
-    function testExpectDecimalsBadFormat() external {
-        BadDecimalsERC20 token = new BadDecimalsERC20();
-        SafeERC20User user = new SafeERC20User(token);
-
-        expectIllegalStateError("Decimals call malformed response");
-        user.expectDecimals(address(token));
-    }
-
     function testFailExpectDecimalsNotPresent() external {
         NoDecimalsERC20 token = new NoDecimalsERC20();
         SafeERC20User user = new SafeERC20User(token);
@@ -184,40 +176,6 @@ contract AlwaysRevertERC20 is IERC20 {
 }
 
 contract NoDecimalsERC20 is IERC20 {
-    function totalSupply() external view returns (uint256) {
-        return 0;
-    }
-
-    function allowance(address owner, address spender) external view returns (uint256) {
-        return 0;
-    }
-
-    function balanceOf(address holder) external view returns (uint256) {
-        return 0;
-    }
-
-    function approve(address spender, uint256 value) external returns (bool success) {
-        return false;
-    }
-
-    function transfer(address receiver, uint256 amount) external returns (bool success) {
-        return false;
-    }
-
-    function transferFrom(
-        address owner,
-        address receiver,
-        uint256 amount
-    ) external returns (bool success) {
-        return false;
-    }
-}
-
-contract BadDecimalsERC20 is IERC20 {
-    function decimals() external view returns (string memory) {
-        return "\xF0\x9F\x98\x81";
-    }
-
     function totalSupply() external view returns (uint256) {
         return 0;
     }

--- a/src/test/YearnStETHCurveAdapterV1.t.sol
+++ b/src/test/YearnStETHCurveAdapterV1.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.13;
+
+import {stdCheats} from "forge-std/stdlib.sol";
+import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
+
+import {
+    YearnStETHCurveAdapterV1,
+    InitializationParams as AdapterInitializationParams
+} from "../adapters/yearn/YearnStETHCurveAdapterV1.sol";
+
+import {IWETH9} from "../interfaces/external/IWETH9.sol";
+import {IStableSwap2Pool} from "../interfaces/external/curve/IStableSwap2Pool.sol";
+import {IYearnVaultV2} from "../interfaces/external/yearn/IYearnVaultV2.sol";
+
+import {SafeERC20} from "../libraries/SafeERC20.sol";
+
+import {DSTestPlus} from "./utils/DSTestPlus.sol";
+
+contract YearnStETHCurveAdapterV1Test is DSTestPlus, stdCheats {
+    IYearnVaultV2 constant vault = IYearnVaultV2(0xdCD90C7f6324cfa40d7169ef80b12031770B4325);
+    IWETH9 constant weth = IWETH9(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    IStableSwap2Pool constant curvePool = IStableSwap2Pool(0xDC24316b9AE028F1497c275EB9192a3Ea0f67022);
+    IERC20 constant curvePoolToken = IERC20(0x06325440D014e39736583c165C2963BA99fAf14E);
+
+    YearnStETHCurveAdapterV1 adapter;
+
+    function setUp() external {
+        adapter = new YearnStETHCurveAdapterV1(AdapterInitializationParams({
+            alchemist:       address(this),
+            token:           address(vault),
+            underlyingToken: address(weth),
+            curvePool:       address(curvePool),
+            curvePoolToken:  address(curvePoolToken),
+            ethPoolIndex:    0,
+            stEthPoolIndex:  1
+        }));
+    }
+
+    function testWrap() external {
+        tip(address(weth), address(this), 1e18);
+
+        SafeERC20.safeApprove(address(weth), address(adapter), 1e18);
+        uint256 wrapped = adapter.wrap(1e18, address(0xbeef));
+
+        assertEq(weth.allowance(address(this), address(adapter)), 0);
+        assertEq(vault.balanceOf(address(0xbeef)), wrapped);
+    }
+
+    function testUnwrap() external {
+        tip(address(vault), address(this), 1e18);
+
+        SafeERC20.safeApprove(address(vault), address(adapter), 1e18);
+        uint256 unwrapped = adapter.unwrap(1e18, address(0xbeef));
+
+        assertEq(vault.allowance(address(this), address(adapter)), 0);
+        assertEq(weth.balanceOf(address(0xbeef)), unwrapped);
+    }
+}

--- a/src/test/utils/DSTestPlus.sol
+++ b/src/test/utils/DSTestPlus.sol
@@ -66,8 +66,8 @@ contract DSTestPlus is DSTest {
 
         if (delta > maxDelta) {
             emit log("Error: a ~= b not satisfied [uint]");
-            emit log_named_uint("  Expected", a);
-            emit log_named_uint("    Actual", b);
+            emit log_named_uint("  Expected", b);
+            emit log_named_uint("    Actual", a);
             emit log_named_uint(" Max Delta", maxDelta);
             emit log_named_uint("     Delta", delta);
             fail();


### PR DESCRIPTION
## What is this change?

This change adds the `YearnStETHCurveAdapterV1` contract which allows the Alchemist to accept [yvCurve-stETH](https://etherscan.io/token/0xdCD90C7f6324cfa40d7169ef80b12031770B4325#readContract).

### Wrapping

ETH is directly wrapped into yvCurve-stETH by providing liquidity single sided to the stETH/ETH Curve pool and then depositing the pool tokens into Yearn.

### Unwrapping

yvCurve-stETH is unwrapped by withdrawing yvCurve-stETH from Yearn and then withdrawing liquidity single sided from the stETH/ETH Curve Pool.

## How was this change tested?

A unit test for each `TokenAdapter` function was created and included as part of this change. 