### PR TITLE
chore: drop ds-test remapping

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,12 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-remappings = ['forge-std/=lib/forge-std/src/', 'ds-test/=lib/ds-test/src/', 'solmate/=lib/solmate/src/', 'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts', 'openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts']
+remappings = [
+    'forge-std/=lib/forge-std/src/',
+    'openzeppelin-contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/',
+    'openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/',
+    'solmate/=lib/solmate/src/',
+]
 solc_version = "0.8.13"
 optimizer_runs = 200
 ignored_error_codes = [1878]

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,1 @@
-"ds-test/="../lib/ds-test/src/
-"forge-std/="lib/forge-std/src/
+forge-std/=lib/forge-std/src/


### PR DESCRIPTION
remove unused ds-test remapping

`forge-std` comes with ds-test as its dependency 