### PR TITLE
Minor fixes to make next-alAsset compatible with Connext mint/burn sanity checks

### DIFF
--- a/src/NextAlchemicToken.sol
+++ b/src/NextAlchemicToken.sol
@@ -11,8 +11,6 @@ import {IllegalArgument, IllegalState, Unauthorized} from "./base/Errors.sol";
 import {IERC3156FlashLender} from "../lib/openzeppelin-contracts/contracts/interfaces/IERC3156FlashLender.sol";
 import {IERC3156FlashBorrower} from "../lib/openzeppelin-contracts/contracts/interfaces/IERC3156FlashBorrower.sol";
 
-import {IAlchemicToken} from "./interfaces/IAlchemicToken.sol";
-
 import "./libraries/TokenUtils.sol";
 
 struct InitializationParams {
@@ -112,7 +110,7 @@ contract NextAlchemicToken is ERC20PermitUpgradeable, AccessControlUpgradeable, 
       revert IllegalState();
     }
 
-    // Mint next token to al Asset.
+    // Mint next token to recipient.
     _mint(recipient, amount);
   }
 
@@ -159,7 +157,7 @@ contract NextAlchemicToken is ERC20PermitUpgradeable, AccessControlUpgradeable, 
   ///
   /// @param amount The amount of tokens to be burned.
   function burn(address from, uint256 amount) external {
-    // Burn next tokens from alAsset.
+    // Burn next tokens from `from`.
     _burn(from, amount);
   }
 }

--- a/src/NextAlchemicToken.sol
+++ b/src/NextAlchemicToken.sol
@@ -113,10 +113,7 @@ contract NextAlchemicToken is ERC20PermitUpgradeable, AccessControlUpgradeable, 
     }
 
     // Mint next token to al Asset.
-    _mint(alAsset, amount);
-
-    // Mint alAsset to user. 
-    IAlchemicToken(alAsset).mint(recipient, amount);
+    _mint(recipient, amount);
   }
 
   /// @notice Sets `alAsset` to a new asset.
@@ -163,9 +160,6 @@ contract NextAlchemicToken is ERC20PermitUpgradeable, AccessControlUpgradeable, 
   /// @param amount The amount of tokens to be burned.
   function burn(address from, uint256 amount) external {
     // Burn next tokens from alAsset.
-    _burn(alAsset, amount);
-
-    // Burn alAsset from user.
-    IAlchemicToken(alAsset).burnFrom(from, amount);
+    _burn(from, amount);
   }
 }


### PR DESCRIPTION
Previous implementation used the following pattern:
1. Connext protocol calls mint/burn
2. `NextAlchemicToken.sol` mints/burns itself to the canonical `AlchemicToken` address
3. `NexAlchemicToken.sol` calls `AlchemicToken` to mint/burn it back to the recipient/caller

The problem with this approach is that it fails some sanity checks that Connext implements when allowlisting burn/mint tokens:

```
      IBridgeToken candidate = IBridgeToken(_local);
      uint256 starting = candidate.balanceOf(address(this));
      candidate.mint(address(this), 1);
      if (candidate.balanceOf(address(this)) != starting + 1) {
        revert TokenFacet__addAssetId_badMint();
      }
      candidate.burn(address(this), 1);
      if (candidate.balanceOf(address(this)) != starting) {
        revert TokenFacet__addAssetId_badBurn();
      }
 ```
